### PR TITLE
Remove redundant "setopt localoptions"

### DIFF
--- a/n-aliases
+++ b/n-aliases
@@ -7,7 +7,7 @@
 
 emulate -L zsh
 
-setopt localoptions extendedglob
+setopt extendedglob
 zmodload zsh/curses
 
 local IFS="

--- a/n-cd
+++ b/n-cd
@@ -7,7 +7,7 @@
 
 emulate -L zsh
 
-setopt localoptions extendedglob pushdignoredups
+setopt extendedglob pushdignoredups
 
 zmodload zsh/curses
 local IFS="

--- a/n-env
+++ b/n-env
@@ -8,7 +8,7 @@
 
 emulate -L zsh
 
-setopt localoptions extendedglob
+setopt extendedglob
 unsetopt equals
 zmodload zsh/curses
 

--- a/n-functions
+++ b/n-functions
@@ -7,7 +7,7 @@
 
 emulate -L zsh
 
-setopt localoptions extendedglob
+setopt extendedglob
 zmodload zsh/curses
 
 local IFS="

--- a/n-history
+++ b/n-history
@@ -8,7 +8,7 @@
 
 emulate -L zsh
 
-setopt localoptions extendedglob
+setopt extendedglob
 zmodload zsh/curses
 
 local IFS="

--- a/n-kill
+++ b/n-kill
@@ -9,7 +9,6 @@ emulate -L zsh
 
 zmodload zsh/curses
 
-setopt localoptions
 setopt extendedglob
 
 local IFS="

--- a/n-list
+++ b/n-list
@@ -10,7 +10,7 @@
 
 emulate -LR zsh
 
-setopt localoptions typesetsilent localtraps extendedglob noshortloops
+setopt typesetsilent extendedglob noshortloops
 
 zmodload zsh/curses
 

--- a/n-list-draw
+++ b/n-list-draw
@@ -5,7 +5,7 @@ emulate -L zsh
 
 zmodload zsh/curses
 
-setopt localoptions typesetsilent extendedglob
+setopt typesetsilent extendedglob
 
 _nlist_expand_tabs() {
     local chunk="$1"

--- a/n-list-input
+++ b/n-list-input
@@ -5,7 +5,6 @@ emulate -L zsh
 
 zmodload zsh/curses
 
-setopt localoptions
 setopt typesetsilent
 
 # Compute first to show index

--- a/n-preview
+++ b/n-preview
@@ -10,7 +10,7 @@ emulate -L zsh
 
 zmodload zsh/curses
 
-setopt localoptions typesetsilent localtraps extendedglob
+setopt typesetsilent extendedglob
 trap "return" TERM INT QUIT
 trap "_vpreview_exit" EXIT
 


### PR DESCRIPTION
The "setopt localoptions" is unnecessary in functions that do an "emulate -L zsh". The -L option sets localoptions, localtraps, and localpatterns.
http://zsh.sourceforge.net/Doc/Release/Shell-Builtin-Commands.html#index-emulate