### PR TITLE
Fix handling of special keys in search mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Screenshot (more at the [wiki](https://github.com/psprint/zsh-navigation-tools/w
 
 A tool generating a selectable curses-based list of elements that has access to current ZSH session, i.e. has broad capabilities to work together with it. That's `n-list`. The files `n-cd`, `n-env`, `n-kill`, etc. are applications of the tool. Feature highlights include incremental searching, ANSI coloring, grepping and various integrations with ZSH.
 
-This is an alternative approach to idea of visual shell, when compared to Midnight Commander. Here the command line is the main way the shell is used. From that mode of operation, user call tools that do not require mouse or typing, only navigating. 
+This is an alternative approach to idea of visual shell, when compared to Midnight Commander. Here the command line is the main way the shell is used. From that mode of operation, user call tools that do not require mouse or typing, only navigating.
 
 ZNT can be compared to IDEs, integrated development environments. Typically, when user searches for occurences of a symbol throughout the project, what IDE does is that it provides a list that can be navigated.
 
@@ -62,12 +62,15 @@ The tools are:
 All tools support horizontal scroll with `<`,`>` or `{`,`}`. Other keys are:
 
 - `[`,`]` - jump directory bookmarks in `n-cd` and typical signals in `n-kill`
-- `/` - start incremental search
 - `Ctrl-d`, `Ctrl-u` - half page up or down
 - `Ctrl-p`, `Ctrl-n` - previous and next (also done with vim's j,k)
 - `Ctrl-l` - redraw of whole display
 - `g, G` - beginning and end of the list
+- `/` - start incremental search
+- 'Enter' - finish incremental search, applying filter
+- 'Esc' - exit incremental search, clearing filter
 - `Ctrl-w` (in incremental search) - delete whole word
+- `Ctrl-k` (in incremental search) - delete whole line
 
 ## Programming
 
@@ -91,4 +94,3 @@ Result is stored as $reply[REPLY]. The returned array might be different from
 input arguments as `n-list` can process them via incremental search. $REPLY is
 the index in that possibly processed array. If $REPLY equals -1 it means that no
 selection have been made (user quitted via 'q' key).
-

--- a/n-list-input
+++ b/n-list-input
@@ -136,6 +136,9 @@ case "$key" in
     ('>'|'}')
         hscroll+=7
         ;;
+    ($'\E')
+        buffer=""
+        ;;
     (*)
         ;;
 esac
@@ -190,6 +193,9 @@ case "$key" in
         current_idx=last_element
         _nlist_compute_first_to_show_idx
         ;;
+    (LEFT|RIGHT|F1|F2|F3|F4|F5|F6|F7|F8|F9|F10)
+        # ignore
+        ;;
 
     #
     # The input
@@ -201,8 +207,19 @@ case "$key" in
     ()
         [ "$buffer" = "${buffer% *}" ] && buffer="" || buffer="${buffer% *}"
         ;;
+    ($'\C-K')
+        buffer=""
+        ;;
+    ($'\E')
+        buffer=""
+        search=0
+        ;;
     (*)
-        buffer+="$key"
+        if [[ $#key == 1 && $((#key)) -lt 31 ]]; then
+            # ignore all other control keys
+        else
+            buffer+="$key"
+        fi
         ;;
 esac
 


### PR DESCRIPTION
Fixes #4.

Fixes left/right arrows, F1-F10 keys, and Ctrl-* causing bogus text additions to the search buffer.
Adds key bindings:
* Esc to exit search
* Ctrl-K to delete entire search buffer

I think it might make more sense to bind "delete entire search buffer" to Ctrl-U, which is currently bound to "half page up". Ctrl-U is the default binding in Emacs for "kill whole line", corresponding to the Ctrl-W binding for "kill word". Maybe "half page up" could be bound to something else.